### PR TITLE
FIX the nomad template for psc-amar-connector so that the AMAR IN API URL gets properly set.

### DIFF
--- a/async-listener.nomad.tpl
+++ b/async-listener.nomad.tpl
@@ -54,7 +54,7 @@ spring.rabbitmq.port={{ .Port }}{{ end }}
 spring.rabbitmq.username={{ with secret "psc-ecosystem/${nomad_namespace}/rabbitmq" }}{{ .Data.data.user }}
 spring.rabbitmq.password={{ .Data.data.password }}{{ end }}
 spring.rabbitmq.listener.simple.default-requeue-rejected=false
-in.api.url={{ with secret "psc-ecosystem/${nomad_namespace}/amar" }}{{ .Data.data.amar_api_url }}{{ end }}
+in.amar.url={{ with secret "psc-ecosystem/${nomad_namespace}/amar" }}{{ .Data.data.amar_api_url }}{{ end }}
 {{ range service "${nomad_namespace}-psc-api-maj-v2" }}psc.api.url=http://{{ .Address }}:{{ .Port }}/psc-api-maj/api{{ end }}
 amar.production.ready={{ with secret "psc-ecosystem/${nomad_namespace}/amar" }}{{ .Data.data.send_to_amar }}{{ end }}
 EOF


### PR DESCRIPTION
Closes #28 